### PR TITLE
[Improvement] Opened tab in Profile page should persist after refreshing

### DIFF
--- a/fe/src/components/base/tabs.vue
+++ b/fe/src/components/base/tabs.vue
@@ -35,4 +35,12 @@ defineEmits(["change-tab"]);
 const tabsProps = defineProps<TabsProps>();
 
 const { activeTab, items } = toRefs(tabsProps);
+
+watch(
+  activeTab,
+  () => {
+    useCookie("active-tab").value = activeTab.value;
+  },
+  { immediate: true },
+);
 </script>

--- a/fe/src/components/user/donations.vue
+++ b/fe/src/components/user/donations.vue
@@ -168,6 +168,9 @@ const getUserDonations = async (pageNumber: number) => {
         }
       })
       .catch((error) => {
+        const errorCode = JSON.parse(JSON.stringify(error)).code;
+        if (errorCode === "UNCONFIGURED_NAME" || errorCode === undefined)
+          return;
         toast.error(error.reason);
       })
       .finally(() => {

--- a/fe/src/pages/index.vue
+++ b/fe/src/pages/index.vue
@@ -91,7 +91,7 @@
               ></CampaignCard>
             </div>
             <div
-              v-if="!isLoading"
+              v-if="!isLoading && recentCampaign.length >= 6"
               class="w-full mt-8 h-14 flex items-center justify-center"
             >
               <NuxtLink

--- a/fe/src/pages/profile.vue
+++ b/fe/src/pages/profile.vue
@@ -65,7 +65,7 @@ const itemsPerPage = 6;
 const currentPage = 1;
 
 const profileTabs = ["My Campaigns", "Donators", "Donations"];
-const activeTab = ref("My Campaigns");
+const activeTab = ref(useCookie("active-tab").value);
 
 const getDonatorsByWalletAddress = async (
   walletAddress: string,


### PR DESCRIPTION
## Issue Link
- [Backlog link](https://framgiaph.backlog.com/view/SPH_SOLIDITY-95)

## Target Page | Component | Function
- ./profile

## Pre-condition
- Add here

## Steps | Commands
1. Switch tabs between ["My Campaigns", "Donators", "Donations"]
2. Every switch, hit refresh

## Expected Output
- After refreshing, it should retain to the selected active tab

## Definition of Done
- Add here

## Test View Points
- [ ] Add here

## Notes
N/A

## Screenshots | Recordings

https://github.com/framgia/sph-solidity/assets/104751512/a1e7f0ca-c2e5-46a3-aa36-e56c6914494a



## Code Review

### General
- [ ] Does the code meet the requirements of the project?
- [ ] Is the code readable and maintainable?
- [ ] Are there any unnecessary or redundant lines of code?
- [ ] Are there any long methods or functions that should be refactored?
- [ ] Are there any performance issues?

### Functionality
- [ ] Are there any logical errors?
- [ ] Are edge cases handled properly?
- [ ] Are there any potential security vulnerabilities?

### Code Style
- [ ] Does the code adhere to the project's coding standards?
- [ ] Are variable and function names descriptive and meaningful?
- [ ] Is there proper use of comments and documentation?
- [ ] Is the code properly formatted? Are indentation, spacing, and formatting consistent?

### Security
- [ ] Is the website secure from common attacks?
- [ ] Are inputs properly validated and sanitized?
- [ ] Are sensitive data and credentials properly protected?

### Testing
- [ ] Are there sufficient test cases?
- [ ] Do the test cases cover all functionality?
- [ ] Are the test cases properly written and documented?

### Additional Comments
- [ ] Are there any other issues or concerns with the code?
- [ ] Are there any suggestions for improvement?
- [ ] Are there any positive aspects of the code that should be highlighted?
